### PR TITLE
Add lat/lon to the output of the service call

### DIFF
--- a/custom_components/prix_carburant/__init__.py
+++ b/custom_components/prix_carburant/__init__.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_NAME, CONF_SCAN_INTERVAL
+from homeassistant.const import ATTR_NAME, CONF_SCAN_INTERVAL, ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.core import (
     HomeAssistant,
     ServiceCall,
@@ -115,6 +115,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "name": station_data[ATTR_NAME],
                     "price": station_data.get(ATTR_PRICE),
                     "address": f"{station_data[ATTR_ADDRESS]}, {station_data[ATTR_POSTAL_CODE]} {station_data[ATTR_CITY]}",
+                    "latitude": f"{station_data[ATTR_LATITUDE]}",
+                    "longitude": f"{station_data[ATTR_LONGITUDE]}",
                 }
                 for station_data in stations.values()
             ],


### PR DESCRIPTION
Although lat/lon are not immediately usable in map-card this way, I found a way to extract the individual stations as 'zone' (using Spook). 
With that I can 
A. use the service call to update the stations around my device (phone)
B. use an automation to 
- delete existing zones for stations
- create zone for each of the stations

Hence I need the lat/lon in the output.
Once you have updated this in a release I will document the whole setup with automation

![image](https://github.com/user-attachments/assets/4eb4129c-c1d7-4dfd-9c64-866332e5a426)


