### PR TITLE
Ajout Logo Total pour les Stations Elan

### DIFF
--- a/custom_components/prix_carburant/stations_name.json
+++ b/custom_components/prix_carburant/stations_name.json
@@ -39150,5 +39150,17 @@
   "83130007": {
     "name": "Carrefour Contact La Garde",
     "brand": "Carrefour"
+  },
+  "67500009": {
+    "name": "LECLERC HAGUENAU",
+    "brand": "Leclerc"
+  },
+  "67500012": {
+    "name": "Supermarché Auchan Haguenau",
+    "brand": "Auchan"
+  },
+  "67510001": {
+    "name": "Carrefour EXPRESS Lembach",
+    "brand": "Carrefour"
   }
 }

--- a/custom_components/prix_carburant/tools.py
+++ b/custom_components/prix_carburant/tools.py
@@ -407,7 +407,7 @@ def get_entity_picture(brand: str) -> str:  # noqa: C901
             return "https://upload.wikimedia.org/wikipedia/commons/6/69/Spar_logo_without_red_background.png"
         case "Système U" | "Super U" | "Station U":
             return "https://upload.wikimedia.org/wikipedia/fr/1/13/U_commer%C3%A7ants_logo_2018.svg"
-        case "Total" | "Total Access":
+        case "Total" | "Total Access" | "Elan":
             return (
                 "https://upload.wikimedia.org/wikipedia/fr/f/f7/Logo_TotalEnergies.svg"
             )


### PR DESCRIPTION
Ajout du logo Total pour les stations Elan. (C'est le même groupe).