### PR TITLE
Make the configuration URL a deep link ...

### DIFF
--- a/custom_components/prix_carburant/sensor.py
+++ b/custom_components/prix_carburant/sensor.py
@@ -134,7 +134,7 @@ class PrixCarburant(CoordinatorEntity, RestoreSensor):
             manufacturer=station_info.get(ATTR_BRAND, "Station"),
             model=self.station_id,
             name=station_name,
-            configuration_url="https://www.prix-carburants.gouv.fr/",
+            configuration_url="https://www.prix-carburants.gouv.fr/station/" + str(self.station_id),
         )
         self._attr_extra_state_attributes = {
             ATTR_NAME: normalize_string(self.station_info[ATTR_NAME]),


### PR DESCRIPTION
.. directly to the station, rather than just the landing page of https://www.prix-carburants.gouv.fr